### PR TITLE
Add Cloud Agent dev environment (ROS 2 Jazzy + Gazebo Harmonic)

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Configuring apt repositories (ROS 2 Jazzy + Gazebo)"
+if [ ! -f /etc/apt/sources.list.d/ros2.list ]; then
+  sudo apt-get update
+  sudo apt-get install -y curl gnupg lsb-release software-properties-common
+  sudo add-apt-repository -y universe
+  sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+    -o /usr/share/keyrings/ros-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo "$UBUNTU_CODENAME") main" \
+    | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+fi
+
+if [ ! -f /etc/apt/sources.list.d/gazebo-stable.list ]; then
+  sudo curl -sSL https://packages.osrfoundation.org/gazebo.gpg \
+    -o /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+fi
+
+echo "==> Installing ROS 2 Jazzy, Gazebo Harmonic and build tooling"
+sudo apt-get update
+sudo apt-get install -y \
+  ros-jazzy-desktop \
+  ros-dev-tools \
+  python3-colcon-common-extensions \
+  python3-rosdep \
+  python3-vcstool \
+  python3-venv \
+  build-essential \
+  cmake \
+  git \
+  xvfb \
+  gz-harmonic \
+  ros-jazzy-ros-gz \
+  ros-jazzy-ros-gz-sim \
+  ros-jazzy-ros-gz-bridge \
+  ros-jazzy-ros-gz-interfaces \
+  ros-jazzy-ackermann-msgs \
+  ros-jazzy-tf-transformations \
+  ros-jazzy-velodyne-msgs \
+  python3-transforms3d \
+  python3-numpy \
+  python3-yaml
+
+echo "==> Initialising rosdep"
+if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
+  sudo rosdep init
+fi
+rosdep update
+
+echo "==> Setting up Python virtual environment (system-site-packages)"
+VENV_DIR="$REPO_DIR/.venv"
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv --system-site-packages "$VENV_DIR"
+fi
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip
+pip install pyaml transforms3d
+
+echo "==> Resolving ROS dependencies with rosdep"
+source /opt/ros/jazzy/setup.bash
+rosdep install --from-paths "$REPO_DIR" --ignore-src -r -y \
+  --skip-keys "zed_wrapper zed_components zed_ros2 zed_msgs velodyne" \
+  || echo "rosdep reported unresolved keys (expected for proprietary ZED packages)"
+
+echo "==> Building the colcon workspace (excluding ZED-dependent bringup)"
+cd "$REPO_DIR"
+export CC=gcc
+export CXX=g++
+colcon build --symlink-install \
+  --packages-skip bringup ultralytics_ros mission_supervisor \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+
+echo "==> Configuring shell environment for interactive use"
+BASHRC="$HOME/.bashrc"
+MARKER="# >>> gra-ros2 workspace >>>"
+if ! grep -qF "$MARKER" "$BASHRC" 2>/dev/null; then
+  {
+    echo ""
+    echo "$MARKER"
+    echo "source /opt/ros/jazzy/setup.bash"
+    echo "[ -f \"$REPO_DIR/install/setup.bash\" ] && source \"$REPO_DIR/install/setup.bash\""
+    echo "[ -f \"$REPO_DIR/.venv/bin/activate\" ] && source \"$REPO_DIR/.venv/bin/activate\""
+    echo "export CC=gcc"
+    echo "export CXX=g++"
+    MODELS="$REPO_DIR/install/simulation/share/simulation/models"
+    echo "export GZ_SIM_RESOURCE_PATH=\"$MODELS/tracks:$MODELS/vehicle:$MODELS/cones:$MODELS/world:$MODELS/sensors\""
+    echo "# <<< gra-ros2 workspace <<<"
+  } >> "$BASHRC"
+fi
+
+echo "==> Install complete"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ build/
 *.egg
 
 .pytest_cache/
+
+# colcon workspace artifacts
+install/
+log/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for this ROS 2 Jazzy / Gazebo Harmonic autonomous-racing stack, and validates it end to end.

Adds `.cursor/install.sh`, an idempotent bootstrap that:

- Configures the ROS 2 Jazzy and Gazebo (OSRF) apt repositories.
- Installs `ros-jazzy-desktop`, Gazebo Harmonic (`gz-harmonic`), `ros_gz` (sim/bridge/interfaces), `ackermann_msgs`, colcon/rosdep tooling, `xvfb`, and Python deps.
- Runs `rosdep install` (skipping proprietary ZED / Velodyne keys) and a Python venv (`--system-site-packages`).
- Builds the workspace with `colcon build --symlink-install`, forcing `gcc/g++` (the base image defaults `c++` to Clang, which cannot link `-lstdc++`).
- Appends idempotent ROS/workspace sourcing + `GZ_SIM_RESOURCE_PATH` to `~/.bashrc`.

Also ignores colcon `install/` and `log/` artifacts in `.gitignore`.

### Build scope

Builds the 6 core packages: `common_msgs`, `fsai_api`, `control`, `path_planning`, `slam`, `simulation`.

Excluded from the default build (documented, not environment issues):

- `bringup` — depends on the proprietary ZED SDK packages (`zed_wrapper`, `zed_components`, …).
- `ultralytics_ros` (perception) — source uses the removed `<cv_bridge/cv_bridge.h>` (Jazzy ships only `.hpp`) and needs GPU + PyTorch/YOLO + a rendered camera at runtime.
- `mission_supervisor` — depends on `ultralytics_ros`.

## Validation

Local VM (headless):

- colcon build: 6/6 core packages succeed; install script idempotent (incremental rebuild 1.25s).
- Gazebo Harmonic 8.11 runs headless (server-only, `--headless-rendering`, `xvfb`): world `map` loads, physics `/clock` advances, `ads_dv` spawns.
- `ros_gz` bridge streams `/odom`, `/clock`, `/imu/data`, `/joint_states`, `/logical_camera`.
- Ground-truth perception: logical camera reports 48 track cones (blue/yellow/orange).
- Closed-loop actuation: `/speed_cmd` → Gazebo physics → vehicle drives 12.87 m (y −12.0 → 0.87), reflected in `/odom`.
- Autonomy pipeline: `pathfinder` (cone map → `/path`, 10 waypoints) → `mppi` controller (`/path` + `/odom` → `/drive`, Ackermann speed 3.03 m/s, steering 0.074 rad).

Prebuilt environment build + fresh Cloud Agent (booted from the tested build): 6/6 checks pass — correct OS/toolchain (ROS 2 Jazzy, Gazebo 8.11, gcc 13), all six packages present, gcc/g++ + ROS/Gazebo auto-sourcing, working MPPI runtime node, and a clean incremental gcc build (no `-lstdc++` error).

## Notes

- `path_planning/scripts/pathfinder.py` lacks the executable bit, so `ros2 run path_planning pathfinder.py` reports "No executable found"; run via `python3 install/path_planning/lib/path_planning/pathfinder.py`. Left as-is (application concern).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccebc657-9327-4eca-ae76-75e7d3e8f66a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccebc657-9327-4eca-ae76-75e7d3e8f66a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

